### PR TITLE
docs: evaluation dimensions and a staleness-resistance method

### DIFF
--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -1,0 +1,62 @@
+# Evaluation
+
+Sketches for how a conforming memory system could be evaluated, and what the
+existing benchmarks do not currently cover.
+
+Companion to the benchmarks section of the prior-art survey, which catalogues
+LongMemEval, MemoryAgentBench, AgentMemBench and Memory-R1. This directory does
+not repeat that survey. It starts from what those benchmarks measure and asks
+what a protocol conformance story would additionally need.
+
+## What the existing benchmarks measure
+
+Recall accuracy, under increasingly realistic conditions. Can the system find
+the fact, across long horizons, across sessions, across distractors.
+
+## What they do not measure
+
+**Where the contract sits.** If the contract between an implementer and a memory
+format is what enters the context window and what stays out, that is not what is
+currently measured. Benchmarks measure what the store returned. Between the store
+and the window sit ranking, truncation, compaction and whatever the harness does
+last, and none of it is instrumented. A system can report a clean result set that
+reaches the model as something else.
+
+**Whether the retrieved memory was the one that should have been returned.** A
+system can retrieve accurately and still return a fact superseded last quarter,
+or scoped to a different project, or one the requesting user had no right to see.
+Retrieval succeeded, which is what makes this failure hard to notice and hard to
+debug. It is a common enough experience that some users disable memory features
+rather than reason about them.
+
+**Whether a past run can be reconstructed.** Not whether the same query returns
+the same answer today, but whether the context assembled on a given date can be
+rebuilt and shown to be what it was. That requires version history and an
+assembly log, which is a structural property rather than an algorithmic one.
+
+**Whether the same memory behaves the same on a different model.** Portability
+that moves bytes but not behaviour is a weaker promise than it sounds.
+
+**Whether memory helped at all.** Memory sometimes makes an agent worse, and a
+protocol that cannot detect that will be adopted and then quietly resented.
+
+## What this directory proposes
+
+Seven dimensions grouped by where the measurement is taken, in [evaluation-dimensions.md](evaluation-dimensions.md),
+and one of them worked through in enough detail to actually run, in
+[staleness-resistance.md](staleness-resistance.md).
+
+These are dimensions, not a leaderboard. The natural place to report them is the
+Mila and Mozilla Agent Memory System Card, which is already designed for systems
+to describe themselves along axes rather than to be ranked. Nothing here needs a
+separate scoreboard, and a separate scoreboard would probably be worse.
+
+## Open questions
+
+- Should conformance require reporting on any of these, or is disclosure enough?
+- Scope isolation needs a labelled corpus with overlapping personas. Does one
+  exist, or does the group need to build it?
+- Net benefit requires a task suite. Is that in scope for a memory protocol, or
+  does it belong with the harnesses?
+- Where should a determinism claim be reported: as a property on the system card,
+  or as a field on the memory object?

--- a/evaluation/evaluation-dimensions.md
+++ b/evaluation/evaluation-dimensions.md
@@ -1,0 +1,149 @@
+# Evaluation dimensions
+
+Axes a memory system could report against, organised by **where the measurement
+is taken**. That grouping is deliberate: existing benchmarks measure the store,
+while the thing an implementer contracts to deliver is the context window.
+
+The framing throughout is disclosure rather than ranking. A system scoring poorly
+on an axis it does not claim to serve has not failed. It has been honest about
+its scope.
+
+---
+
+## A. At assembly time: what actually entered the window
+
+If the contract is what goes into the context window and what stays out, almost
+nothing currently measures it directly. Benchmarks measure what the
+store returned, which is a different quantity separated from the window by
+ranking, truncation, compaction and whatever the harness does last.
+
+### A1. Assembly fidelity
+
+**Measures:** the difference between what the memory system selected and what the
+model actually received.
+
+**Why it is not covered:** it requires instrumentation at the harness boundary,
+not the store boundary. A store can report a perfect result set that is then
+truncated, reordered, or summarised into something else.
+
+**How:** capture the assembled context at the point of inference. Report, per
+query: items selected, items that survived to the window, items dropped, and
+what dropped them (budget, ranking, compaction, deduplication). A system that
+cannot produce this record cannot report the axis.
+
+This is the axis that most needs the access-protocol work, because it can only be
+measured where the harness and the memory system meet.
+
+### A2. Budget efficiency
+
+**Measures:** input tokens consumed per accepted answer.
+
+**How:** hold answer quality fixed and report token cost, or report both and show
+the tradeoff. This is where selective retrieval either justifies itself or does
+not.
+
+---
+
+## B. On the selection: was it the right content
+
+### B1. Staleness resistance
+
+**Measures:** when a corpus holds a fact and its superseded predecessor, how
+often the current one comes back.
+
+**Why it is not covered:** benchmarks build corpora where the target is correct
+and other content is a distractor. Superseded content is a near-duplicate, not a
+distractor, and it is frequently the better lexical match because it was written
+when the topic was live.
+
+Worked through in [staleness-resistance.md](staleness-resistance.md).
+
+### B2. Scope isolation
+
+**Measures:** when memories belong to different projects, personas or
+permissions, how often retrieval crosses a boundary it should not.
+
+**Why it is not covered:** benchmarks are typically single-scope. Everything in
+the corpus is legitimately available to the query.
+
+**How:** a corpus partitioned into overlapping scopes with deliberately similar
+content, queries labelled by originating scope, scored on the proportion of
+returned items from the wrong scope. This is the measurable form of a familiar
+failure: asking a question in one role and being answered as though you were in
+another.
+
+A system with no scope model cannot score here, which is the useful signal.
+
+---
+
+## C. Across runs and models: can the result be relied on
+
+### C1. Repeatability
+
+**Measures:** whether a past run can be reconstructed. Not whether the same query
+returns the same answer today, but whether the exact context assembled on a given
+date can be rebuilt and shown to be what it was.
+
+**Why it is separate from determinism:** a deterministic selector gives you the
+same answer twice under identical conditions. Repeatability asks a harder
+question, because conditions change. The store has been written to since. To
+reconstruct, a system needs the version history of every item and a log of what
+was assembled, which is a structural requirement rather than an algorithmic one.
+
+**How:** run a query, record the assembled context, continue writing to the store
+for a period, then ask the system to reproduce the original assembly. Score exact
+reconstruction, partial reconstruction, and failure.
+
+**This axis has a prerequisite, and stating it is the point.** A system without
+per-item version history and an assembly log cannot pass at any level. That is
+not a criticism of such systems. It does mean that if a protocol wants
+reconstruction to be a property implementers can rely on, the fields it depends
+on cannot be optional.
+
+Determinism of the selector should be reported alongside, as a three-valued
+property (deterministic, non-deterministic, or configurable) rather than scored.
+A pass or fail framing flatters architectures that chose determinism and
+penalises approaches that traded it away deliberately.
+
+### C2. Cross-model consistency
+
+**Measures:** whether the same memory produces consistent behaviour when supplied
+to different models.
+
+**Why it matters:** portability that moves bytes but not behaviour is not
+portability. If the same memory yields different answers on different models,
+"take your memory with you" is a weaker promise than it sounds.
+
+**How:** hold the assembled context fixed, vary the model across a set, and
+measure agreement on a fixed question set. Report agreement rate and the models
+tested, since the result is only meaningful relative to the set.
+
+Prior art exists: the Portable Agent Memory work reports transfer continuity
+scores of 0.83 to 0.92 across four model families. That metric or something like
+it is a reasonable starting point rather than something to invent fresh.
+
+---
+
+## D. On the outcome: did any of it help
+
+### D1. Net task benefit
+
+**Measures:** whether the memory system improves task outcomes against two
+baselines: no memory, and the same content supplied in full context.
+
+**Why it is not covered:** benchmarks measure retrieval quality, not whether
+retrieval helped. Memory sometimes makes an agent worse, and nothing currently
+detects that.
+
+**How:** a fixed task suite run three ways, reporting the delta. The full-context
+baseline separates "memory helped" from "this content helped, and memory was an
+expensive way to deliver it."
+
+---
+
+## Not here, deliberately
+
+Storage efficiency, write throughput and extraction quality. These are
+implementation concerns that sit below the protocol per the standards sketches.
+They matter to operators and belong in vendor documentation rather than in a
+conformance story.

--- a/evaluation/staleness-resistance.md
+++ b/evaluation/staleness-resistance.md
@@ -1,0 +1,117 @@
+# Staleness resistance
+
+A method for measuring whether a memory system returns the current version of a
+fact when a superseded version is also present.
+
+This is written to be runnable by anyone, against any memory system, without
+agreeing to a protocol first. It needs no shared corpus and no central
+scoreboard. If the group finds it useful, the output belongs on a system card
+rather than a leaderboard.
+
+## Why this and not recall accuracy
+
+Recall benchmarks build corpora where the target fact is correct and everything
+else is a distractor. Real stores accumulate a different problem: the same fact,
+written twice, at different times, with a different value. Both versions are
+about the right subject. Both are relevant. One is wrong.
+
+Retrieval quality does not resolve this, because the superseded version is
+often the better lexical and semantic match. It was written when the topic was
+being actively discussed, so it tends to be longer, more detailed and more
+specific than the terse correction that replaced it.
+
+## Corpus construction
+
+1. Choose a domain with genuine revisions. Policy documents, pricing, clinical
+   guidance, configuration and internal process all work. Synthetic corpora are
+   acceptable but should be disclosed, since real supersession is messier.
+
+2. Build **paired documents**. Each pair shares a subject and differs in one
+   material value. The later document is the current one.
+
+3. Vary the **supersession signal** across the corpus, because systems differ in
+   what they can see:
+   - explicit relation on the object (`supersedes`, or equivalent)
+   - status transition (the earlier becomes deprecated or retracted)
+   - timestamp only
+   - no signal at all beyond content
+
+   Report per condition. A system that only handles the explicit case is not
+   broken; it is scoped, and the report should say so.
+
+4. Add unpaired documents so pairs are not the majority of the corpus.
+   Suggested ratio: pairs no more than one third of documents.
+
+5. Record ground truth per pair: subject, current value, superseded value.
+
+## Query set
+
+One query per pair, phrased for the value rather than the document. "What is the
+current X" rather than "find document Y." Include paraphrases that do not share
+vocabulary with either version, since that is where lexical and semantic
+approaches diverge most.
+
+## Scoring
+
+For each query, classify the response:
+
+| Outcome | Meaning |
+|---|---|
+| **Current** | Cites or reflects the current value |
+| **Superseded** | Cites or reflects the replaced value |
+| **Both** | Returns both without indicating which supersedes |
+| **Neither** | Retrieval failure, unrelated to staleness |
+
+**Staleness resistance** = Current / (Current + Superseded + Both).
+
+Report `Neither` separately. It is a recall failure and mixing it in confuses a
+staleness measure with a retrieval measure.
+
+`Both` counts against the system deliberately. Returning a contradiction without
+resolving it moves the problem to the model, which is where it becomes invisible.
+
+## Baselines
+
+Three, run against the same corpus:
+
+- **No memory.** Establishes the floor.
+- **Full context**, where the corpus fits. Separates "the system found it" from
+  "the content was available and any method would have worked."
+- **A lexical baseline**, BM25 or similar. Cheap, strong, and the honest thing to
+  beat.
+
+## What to report
+
+- Staleness resistance per supersession condition
+- `Neither` rate
+- Input tokens per query, since selectivity that costs ten times the tokens is a
+  different product
+- Corpus provenance: real, synthetic, or mixed
+- Size, and pair proportion
+
+## Known limitations
+
+**Synthetic supersession is cleaner than real supersession.** Real corpora
+contain partial revisions, documents that supersede in one respect and not
+another, and revisions nobody marked. Results on constructed corpora will be
+optimistic for every system measured.
+
+**This rewards architectures that model versions.** A system with no version
+concept scores poorly by construction. That is informative rather than unfair,
+but it should not be read as a general quality judgement, and a system card
+should carry the scope alongside the score.
+
+**Single-hop only.** It does not measure whether a system correctly propagates a
+supersession through derived or summarized memories, which is the harder and
+more realistic version of the problem.
+
+## One reference point
+
+We ran a version of this while writing arXiv:2607.02116. On a corpus where each
+fact had a superseded predecessor, selection that honoured version and status
+returned the current fact 97% of the time, against 93-90% for BM25, at roughly
+one third the input tokens.
+
+That is one system on one corpus and should be read as an existence proof that
+the measurement discriminates, not as a result about the field. The method is
+more useful than the number, which is why the method is written out above.


### PR DESCRIPTION
Evaluation came up a few times without an owner, so this is a starting point to react to rather than a proposal.

It does not repeat the benchmark survey in #3, which already covers LongMemEval, MemoryAgentBench, AgentMemBench and Memory-R1. It starts from what those measure, which is recall accuracy, and asks what a conformance story would additionally need.

Dimensions are grouped by **where the measurement is taken**. Benchmarks measure what the store returned, but the thing an implementer contracts to deliver is the context window, and between the two sit ranking, truncation and compaction that nothing currently instruments.

- **At assembly time**: assembly fidelity, budget efficiency
- **On the selection**: staleness resistance, scope isolation
- **Across runs and models**: repeatability, cross-model consistency
- **On the outcome**: net task benefit

Two things this deliberately avoids. It is not a leaderboard, and the natural home for these is the Mila and Mozilla system card, which is already built for systems to describe themselves along axes. And determinism is reported as a property rather than scored, because a pass/fail framing flatters architectures that chose it.

`staleness-resistance.md` is written out far enough to run: corpus construction, four supersession conditions, a scoring rubric, and three baselines including BM25. Its limitations section notes that the method rewards architectures that model versions, which seemed worth stating before anyone adopts it.

Open questions are at the end of the README. Rewrite or drop whatever does not fit.